### PR TITLE
fix: ga

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -2,12 +2,13 @@ import { Html, Head, Main, NextScript } from 'next/document'
 import Script from 'next/script'
 
 export default function Document() {
+  const GOOGLE_ANALYTICS_ID = process.env.GOOGLE_ANALYTICS_ID
   return (
     <Html lang="en">
       <Head>
         <Script
           strategy="afterInteractive"
-          src={`https://www.googletagmanager.com/gtag/js?id=${process.env.GOOGLE_ANALYTICS_ID}`}
+          src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID}`}
         ></Script>
         <Script
           id="gtag-init"
@@ -17,7 +18,7 @@ export default function Document() {
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
-              gtag('config', 'G-MEASUREMENT_ID');
+              gtag('config', '${GOOGLE_ANALYTICS_ID}');
               `,
           }}
         />


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Added a constant `GOOGLE_ANALYTICS_ID` to store the value of `process.env.GOOGLE_ANALYTICS_ID`.
- Updated the `src` attribute of the `<Script>` component to use the `GOOGLE_ANALYTICS_ID` constant instead of `process.env.GOOGLE_ANALYTICS_ID`.
- Updated the `gtag` function call to use the `GOOGLE_ANALYTICS_ID` constant instead of a hard-coded value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->